### PR TITLE
Update `[py]heavydb` after Conda-forge release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,0 @@
-**/__pycache__
-!dist/
-**/pytest_cache/
-.vscode/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 def precommit_container_image = "sloria/pre-commit"
 def precommit_container_name = "heavyai-precommit-$BUILD_NUMBER"
-def db_cuda_container_image = "omnisci/core-os-cuda"
-def db_cpu_container_image = "omnisci/core-os-cpu"
+def db_cuda_container_image = "heavyai/core-os-cuda"
+def db_cpu_container_image = "heavyai/core-os-cpu"
 def stage_succeeded
 def git_commit
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,7 +95,6 @@ pipeline {
                             setBuildStatus("Running tests", "PENDING", "$STAGE_NAME", git_commit);
                             sh """
                                 $WORKSPACE/scripts/run_tests.sh \
-                                    --db-image $db_cpu_container_image \
                                     --cpu-only
                             """
                             script { stage_succeeded = true }
@@ -120,7 +119,6 @@ pipeline {
                             setBuildStatus("Running tests", "PENDING", "$STAGE_NAME", git_commit);
                             sh """
                                 $WORKSPACE/scripts/run_tests.sh \
-                                    --db-image $db_cuda_container_image \
                                     --gpu-only
                             """
                             script { stage_succeeded = true }

--- a/ci/build-conda.sh
+++ b/ci/build-conda.sh
@@ -47,9 +47,9 @@ run_heavydb() {
     export NVIDIA_VISIBLE_DEVICES=all
     export NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics
 
-    mkdir data && initheavy data
+    rm -rf data-db && mkdir data-db && initheavy data-db
     heavydb \
-        --data data \
+        --data data-db \
         --enable-runtime-udfs \
         --enable-table-functions &
 

--- a/ci/build-conda.sh
+++ b/ci/build-conda.sh
@@ -43,6 +43,10 @@ run_heavydb() {
     mamba create -n heavyai-db heavydb
     conda activate heavyai-db
 
+    export CUDA_VERSION=${CUDA_VERSION:-11.0.2}
+    export NVIDIA_VISIBLE_DEVICES=all
+    export NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics
+
     mkdir data && initheavy data
     heavydb \
         --data data \

--- a/ci/build-conda.sh
+++ b/ci/build-conda.sh
@@ -43,8 +43,7 @@ run_heavydb() {
     rm -rf data-db && mkdir data-db && initheavy data-db
     heavydb \
         --data data-db \
-        --enable-runtime-udfs \
-        --enable-table-functions &
+        --enable-runtime-udfs &
 
     sleep 10
 }

--- a/ci/build-conda.sh
+++ b/ci/build-conda.sh
@@ -55,16 +55,6 @@ build_test_gpu() {
 conda install -y mamba
 eval "$(command conda 'shell.bash' 'hook' 2> /dev/null)"
 
-
-startheavy \
-    --non-interactive \
-    --data /heavydb-storage/data \
-    --enable-runtime-udfs \
-    --enable-table-functions \
-    ${db_params[*]} &
-
-sleep 10
-
 if [[ gpu_only -ne 1 ]];then
     echo "================================"
     echo "  Starting CPU Build and Test"
@@ -78,5 +68,19 @@ if [[ cpu_only -ne 1 ]];then
     echo "================================"
     build_test_gpu
 fi
+
+mamba install heavydb
+
+startheavy \
+    --non-interactive \
+    --data /heavydb-storage/data \
+    --enable-runtime-udfs \
+    --enable-table-functions \
+    ${db_params[*]} &
+
+sleep 10
+
+
+
 
 pytest -sv tests/

--- a/ci/build-conda.sh
+++ b/ci/build-conda.sh
@@ -63,7 +63,11 @@ echo "  Installing Dependencies"
 echo "================================"
 mamba env create -f $environment_file
 conda activate $environment_name
-python -c "import cudf"
+
+if [[ gpu_only -eq 1 ]];then
+     python -c "import cudf"
+fi
+
 pip install --no-deps .
 conda deactivate
 

--- a/ci/build-conda.sh
+++ b/ci/build-conda.sh
@@ -59,6 +59,10 @@ build_test_cpu() {
     conda activate heavyai-dev
     which python
     pip install --no-deps .
+
+    conda deactivate
+    run_heavydb
+    conda activate heavyai-dev
 }
 
 build_test_gpu() {
@@ -67,13 +71,15 @@ build_test_gpu() {
     which python
     python -c "import cudf"
     pip install --no-deps .
+
+    conda deactivate
+    run_heavydb
+    conda activate heavyai-gpu-dev
 }
 
 
 conda install -y mamba
 eval "$(command conda 'shell.bash' 'hook' 2> /dev/null)"
-
-run_heavydb
 
 if [[ cpu_only -eq 1 ]];then
     echo "================================"

--- a/ci/build-conda.sh
+++ b/ci/build-conda.sh
@@ -40,13 +40,6 @@ done
 
 
 run_heavydb() {
-    mamba create -n heavyai-db heavydb
-    conda activate heavyai-db
-
-    export CUDA_VERSION=${CUDA_VERSION:-11.0.2}
-    export NVIDIA_VISIBLE_DEVICES=all
-    export NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics
-
     rm -rf data-db && mkdir data-db && initheavy data-db
     heavydb \
         --data data-db \
@@ -54,7 +47,6 @@ run_heavydb() {
         --enable-table-functions &
 
     sleep 10
-    conda deactivate
 }
 
 
@@ -65,7 +57,10 @@ build_test_cpu() {
     pip install --no-deps .
 
     conda deactivate
+    mamba create -n heavyai-db heavydb
+    conda activate heavyai-db
     run_heavydb
+    conda deactivate
     conda activate heavyai-dev
 }
 
@@ -77,7 +72,10 @@ build_test_gpu() {
     pip install --no-deps .
 
     conda deactivate
+    mamba create -n heavyai-db "heavydb=*=*_cuda"
+    conda activate heavyai-db
     run_heavydb
+    conda deactivate
     conda activate heavyai-gpu-dev
 }
 

--- a/ci/build-conda.sh
+++ b/ci/build-conda.sh
@@ -42,7 +42,6 @@ build_test_cpu() {
     mamba env create -f ci/environment.yml
     conda activate heavyai-dev
     pip install --no-deps -e .
-    pytest -sv tests/
 }
 
 build_test_gpu() {
@@ -50,12 +49,21 @@ build_test_gpu() {
     conda activate heavyai-gpu-dev
     python -c "import cudf"
     pip install --no-deps -e .
-    pytest -sv tests/
 }
 
 
 conda install -y mamba
 eval "$(command conda 'shell.bash' 'hook' 2> /dev/null)"
+
+
+startheavy \
+    --non-interactive \
+    --data /heavydb-storage/data \
+    --enable-runtime-udfs \
+    --enable-table-functions \
+    ${db_params[*]} &
+
+sleep 10
 
 if [[ gpu_only -ne 1 ]];then
     echo "================================"
@@ -70,3 +78,5 @@ if [[ cpu_only -ne 1 ]];then
     echo "================================"
     build_test_gpu
 fi
+
+pytest -sv tests/

--- a/ci/build-conda.sh
+++ b/ci/build-conda.sh
@@ -41,12 +41,18 @@ done
 build_test_cpu() {
     mamba env create -f ci/environment.yml
     conda activate heavyai-dev
+    mamba install heavydb
+    conda deactivate
+    conda activate heavyai-dev
     pip install --no-deps -e .
 }
 
 build_test_gpu() {
     mamba env create -f ci/environment_gpu.yml
     conda activate heavyai-gpu-dev
+    mamba install heavydb
+    conda deactivate
+    conda activate heavyai-dev
     python -c "import cudf"
     pip install --no-deps -e .
 }
@@ -69,18 +75,13 @@ if [[ cpu_only -ne 1 ]];then
     build_test_gpu
 fi
 
-mamba install heavydb
-
-startheavy \
-    --non-interactive \
-    --data /heavydb-storage/data \
+mkdir data && initheavy data
+heavydb \
+    --data data \
     --enable-runtime-udfs \
-    --enable-table-functions \
-    ${db_params[*]} &
+    --enable-table-functions &
 
 sleep 10
-
-
 
 
 pytest -sv tests/

--- a/ci/build-conda.sh
+++ b/ci/build-conda.sh
@@ -40,8 +40,8 @@ done
 
 
 run_heavydb() {
-    mamba create -n heavydb heavydb
-    conda activate heavydb
+    mamba create -n heavyai-db heavydb
+    conda activate heavyai-db
 
     mkdir data && initheavy data
     heavydb \
@@ -57,14 +57,16 @@ run_heavydb() {
 build_test_cpu() {
     mamba env create -f ci/environment.yml
     conda activate heavyai-dev
-    pip install --no-deps -e .
+    which python
+    pip install --no-deps .
 }
 
 build_test_gpu() {
     mamba env create -f ci/environment_gpu.yml
     conda activate heavyai-gpu-dev
+    which python
     python -c "import cudf"
-    pip install --no-deps -e .
+    pip install --no-deps .
 }
 
 
@@ -73,14 +75,14 @@ eval "$(command conda 'shell.bash' 'hook' 2> /dev/null)"
 
 run_heavydb
 
-if [[ gpu_only -ne 1 ]];then
+if [[ cpu_only -eq 1 ]];then
     echo "================================"
     echo "  Starting CPU Build and Test"
     echo "================================"
     build_test_cpu
 fi
 
-if [[ cpu_only -ne 1 ]];then
+if [[ gpu_only -eq 1 ]];then
     echo "================================"
     echo "  Starting GPU Build and Test"
     echo "================================"

--- a/ci/build-conda.sh
+++ b/ci/build-conda.sh
@@ -38,11 +38,24 @@ while [[ $# != 0 ]]; do
     esac
 done
 
+
+run_heavydb() {
+    mamba create -n heavydb heavydb
+    conda activate heavydb
+
+    mkdir data && initheavy data
+    heavydb \
+        --data data \
+        --enable-runtime-udfs \
+        --enable-table-functions &
+
+    sleep 10
+    conda deactivate
+}
+
+
 build_test_cpu() {
     mamba env create -f ci/environment.yml
-    conda activate heavyai-dev
-    mamba install heavydb
-    conda deactivate
     conda activate heavyai-dev
     pip install --no-deps -e .
 }
@@ -50,9 +63,6 @@ build_test_cpu() {
 build_test_gpu() {
     mamba env create -f ci/environment_gpu.yml
     conda activate heavyai-gpu-dev
-    mamba install heavydb
-    conda deactivate
-    conda activate heavyai-dev
     python -c "import cudf"
     pip install --no-deps -e .
 }
@@ -75,13 +85,6 @@ if [[ cpu_only -ne 1 ]];then
     build_test_gpu
 fi
 
-mkdir data && initheavy data
-heavydb \
-    --data data \
-    --enable-runtime-udfs \
-    --enable-table-functions &
-
-sleep 10
-
+run_heavydb
 
 pytest -sv tests/

--- a/ci/build-conda.sh
+++ b/ci/build-conda.sh
@@ -71,6 +71,8 @@ build_test_gpu() {
 conda install -y mamba
 eval "$(command conda 'shell.bash' 'hook' 2> /dev/null)"
 
+run_heavydb
+
 if [[ gpu_only -ne 1 ]];then
     echo "================================"
     echo "  Starting CPU Build and Test"
@@ -84,7 +86,5 @@ if [[ cpu_only -ne 1 ]];then
     echo "================================"
     build_test_gpu
 fi
-
-run_heavydb
 
 pytest -sv tests/

--- a/ci/build-conda.sh
+++ b/ci/build-conda.sh
@@ -45,12 +45,14 @@ if [[ gpu_only -eq 1 ]];then
     echo "================================"
     environment_file=ci/environment_gpu.yml
     environment_name=heavyai-gpu-dev
+    heavydb_version="heavydb=*=*_cuda"
 else
     echo "================================"
     echo "  Starting CPU Build and Test"
     echo "================================"
     environment_file=ci/environment.yml
     environment_name=heavyai-dev
+    heavydb_version="heavydb=*=*_cpu"
 fi
 
 
@@ -74,7 +76,7 @@ conda deactivate
 echo "================================"
 echo "  Starting HeavyDB"
 echo "================================"
-mamba create -n heavyai-db "heavydb=*=*_cuda"
+mamba create -n heavyai-db $heavydb_version
 conda activate heavyai-db
 rm -rf data-db && mkdir data-db && initheavy data-db
 heavydb --data data-db &

--- a/ci/build-conda.sh
+++ b/ci/build-conda.sh
@@ -42,8 +42,7 @@ done
 run_heavydb() {
     rm -rf data-db && mkdir data-db && initheavy data-db
     heavydb \
-        --data data-db \
-        --enable-runtime-udfs &
+        --data data-db &
 
     sleep 10
 }

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -20,6 +20,4 @@ dependencies:
 - pytest-mock
 - sphinx
 - sphinx_rtd_theme
-- pip
-- pip:
-    - pyheavydb
+- pyheavydb

--- a/ci/environment_gpu.yml
+++ b/ci/environment_gpu.yml
@@ -24,6 +24,4 @@ dependencies:
 - pytest-mock
 - sphinx
 - sphinx_rtd_theme
-- pip
-- pip:
-    - pyheavydb
+- pyheavydb

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -80,7 +80,7 @@ Unless you are planning on developing GPU-specific functionality in heavyai, usi
      -p 6278:6278 \
      --ipc=host \
      -v /home/<username>/heavydb-storage:/heavydb-storage \
-     omnisci/core-os-cpu
+     heavyai/core-os-cpu
 
 With the above code, we:
    * create/run an instance of HeavyDB Core CPU as a daemon (i.e. running in the background until stopped)
@@ -128,7 +128,7 @@ GPU-enabled`_ container:
      -p 6278:6278 \
      --ipc=host \
      -v /home/<username>/heavydb-storage:/heavydb-storage \
-     omnisci/core-os-cuda
+     heavyai/core-os-cuda
 
 You also need to `install cudf`_ in your development environment. Because cudf is in active development, and requires attention
 to the specific version of CUDA installed, we recommend checking the `cudf documentation`_ to get the most up-to-date
@@ -210,9 +210,9 @@ When the conda-forge bot opens a PR on the heavyai-feedstock repo, one of the fe
 of the PR, check the accuracy of the package versions on the `meta.yaml`_ recipe file, and then merge once the CI tests pass.
 
 .. _HeavyDB: https://github.com/heavyai/heavydb
-.. _Docker: https://hub.docker.com/u/omnisci
-.. _CPU image: https://hub.docker.com/r/omnisci/core-os-cpu
-.. _HeavyDB Core GPU-enabled: https://hub.docker.com/r/omnisci/core-os-cuda
+.. _Docker: https://hub.docker.com/u/heavyai
+.. _CPU image: https://hub.docker.com/r/heavyai/core-os-cpu
+.. _HeavyDB Core GPU-enabled: https://hub.docker.com/r/heavyai/core-os-cuda
 .. _install cudf: https://github.com/rapidsai/cudf#installation
 .. _cudf documentation: https://rapidsai.github.io/projects/cudf/en/latest/
 .. _commit: https://github.com/heavyai/heavyai/commit/28441055959e62443954a9826f1f03d876a1cfdb

--- a/docs/source/releasenotes.rst
+++ b/docs/source/releasenotes.rst
@@ -4,8 +4,8 @@ Release Notes
 =============
 
 The release notes for heavyai are managed on the GitHub repository in the `Releases tab`_. Since heavyai
-releases try to track new features in the main OmniSci Core project, it's highly recommended that you check
-the Releases tab any time you install a new version of heavyai or upgrade OmniSci so that you understand any breaking
+releases try to track new features in the main HeavyDB Core project, it's highly recommended that you check
+the Releases tab any time you install a new version of heavyai or upgrade HeavyDB so that you understand any breaking
 changes that may have been made during a new pymapd release.
 
 Some notable breaking changes include:

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -34,28 +34,15 @@ heavyai
 If you have an NVIDIA GPU in the same machine where your heavyai code will be running, you'll want to `install
 cudf`_ as well to return results sets into GPU memory as a cudf GPU DataFrame:
 
-cudf via conda
-**************
+cudf
+****
+
+cudf is only available on conda. Hence, the use of a conda environment is
+required.
 
 .. code-block:: console
 
-   # CUDA 9.2
-   conda install -c nvidia -c rapidsai -c numba -c conda-forge -c defaults cudf
-
-   # CUDA 10.0
-   conda install -c nvidia/label/cuda10.0 -c rapidsai/label/cuda10.0 -c numba \
-       -c conda-forge -c defaults cudf
-
-cudf via PyPI/pip
-*****************
-
-.. code-block:: console
-
-   # CUDA 9.2
-   pip install cudf-cuda92
-
-   # CUDA 10.0
-   pip install cudf-cuda100
+   conda install -c nvidia -c conda-forge -c defaults cudf cudatoolkit
 
 Connecting
 ----------
@@ -85,7 +72,7 @@ the ``connect()`` method:
 
    >>> uri = "heavydb://admin:HyperInteractive@localhost:6274/heavyai?protocol=binary"
    >>> con = connect(uri=uri)
-   Connection(mapd://admin:***@localhost:6274/heavydb?protocol=binary)
+   Connection(heavydb://admin:***@localhost:6274/heavyai?protocol=binary)
 
 HeavyDB Cloud
 *************
@@ -310,7 +297,7 @@ Python functions to define these as Runtime UDFs:
 .. note::
 
    Runtime UDFs can be defined if the HeavyDB server has enabled its
-   support (see ``--enable-runtime-udf`` option of ``omnisci_server``)
+   support (see ``--enable-runtime-udfs`` option of ``heavydb``)
    and `rbc`_ package is installed. This is still experimental functionality, and
    currently it does not work on the Windows operating system.
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -37,8 +37,7 @@ cudf`_ as well to return results sets into GPU memory as a cudf GPU DataFrame:
 cudf
 ****
 
-cudf is only available on conda. Hence, the use of a conda environment is
-required.
+The pre-built cudf is only available on conda. Hence, the use of a conda environment is required.
 
 .. code-block:: console
 

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -32,7 +32,7 @@ from itertools import product
 import coloredlogs
 from numba import cuda
 
-import pymapd
+import heavyai
 
 try:
     cuda.select_device(0)
@@ -217,10 +217,10 @@ def main(args=None):
     fh.setFormatter(formatter)
     logger.addHandler(fh)
 
-    con = omnisci.connect(
+    con = heavyai.connect(
         user='admin',
         password='HyperInteractive',
-        dbname='omnisci',
+        dbname='heavyai',
         host='localhost')
 
     grid = product(selects.keys(), _benchmarks)

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -117,9 +117,9 @@ start_docker_db() {
 
     docker run "${params[@]}" \
         bash -c "\
-            /omnisci/startomnisci \
+            /heavyai/startheavy \
                 --non-interactive \
-                --data /omnisci-storage/data \
+                --data /heavydb-storage/data \
                 --enable-runtime-udf \
                 --enable-table-functions \
                 ${db_params[*]} \

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -104,8 +104,6 @@ start_docker_db() {
         nvcc --version
         echo ""
         echo "NVIDIA drivers"
-        docker run --runtime=nvidia $db_image bash -c nvidia-smi
-        echo ""
         nvidia-smi
         echo ""
     fi
@@ -122,17 +120,27 @@ start_docker_db() {
     )
 
 
-    echo "Launching docker run with args: ${params[*]}"
+#    echo "Launching docker run with args: ${params[*]}"
+#
+#    docker run "${params[@]}" \
+#        bash -c "\
+#            /opt/heavyai/startheavy \
+#                --non-interactive \
+#                --data /heavydb-storage/data \
+#                --enable-runtime-udfs \
+#                --enable-table-functions \
+#                ${db_params[*]} \
+#            "
 
-    docker run "${params[@]}" \
-        bash -c "\
-            /opt/heavyai/startheavy \
-                --non-interactive \
-                --data /heavydb-storage/data \
-                --enable-runtime-udfs \
-                --enable-table-functions \
-                ${db_params[*]} \
-            "
+    mamba env create -n heavydb heavydb
+    conda activate heavydb
+
+    startheavy \
+            --non-interactive \
+            --data /heavydb-storage/data \
+            --enable-runtime-udfs \
+            --enable-table-functions \
+            ${db_params[*]} &
 
     # Tail logs for 10s to ensure that our db startup was successful.
     timeout 10s docker logs -f "$db_container_name" || true

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -117,10 +117,10 @@ start_docker_db() {
 
     docker run "${params[@]}" \
         bash -c "\
-            /heavyai/startheavy \
+            /opt/heavyai/startheavy \
                 --non-interactive \
                 --data /heavydb-storage/data \
-                --enable-runtime-udf \
+                --enable-runtime-udfs \
                 --enable-table-functions \
                 ${db_params[*]} \
             "

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -99,6 +99,7 @@ start_docker_db() {
 
     if [[ gpu_only -eq 1 ]];then
         params+=("--runtime=nvidia")
+        docker run --runtime=nvidia rapidsai/rapidsai-core:22.04-cuda11.0-base-ubuntu20.04-py3.9 bash -c nvidia-smi
     fi
 
     params+=( \

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -99,7 +99,13 @@ start_docker_db() {
 
     if [[ gpu_only -eq 1 ]];then
         params+=("--runtime=nvidia")
+        echo ""
+        echo "CUDA toolkit version"
+        nvcc --version
+        echo ""
+        echo "NVIDIA drivers"
         docker run --runtime=nvidia rapidsai/rapidsai-core:22.04-cuda11.0-base-ubuntu20.04-py3.9 bash -c nvidia-smi
+        echo ""
     fi
 
     params+=( \

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -104,7 +104,9 @@ start_docker_db() {
         nvcc --version
         echo ""
         echo "NVIDIA drivers"
-        docker run --runtime=nvidia rapidsai/rapidsai-core:22.04-cuda11.0-base-ubuntu20.04-py3.9 bash -c nvidia-smi
+        docker run --runtime=nvidia $db_image bash -c nvidia-smi
+        echo ""
+        nvidia-smi
         echo ""
     fi
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -20,7 +20,6 @@ usage() {
 Usage: $0 [OPTION]...
 Run heavyai tests
 Options:
-  --db-image IMAGE_NAME         Required.
   --cpu-only                    Only build and test for CPU build.
   --gpu-only                    Only build and test for GPU build.
   -h, --help                    Print this help
@@ -28,8 +27,6 @@ EOF
     exit "$exitcode"
 }
 
-db_image= # docker image that hosts the HeavyDB instance
-db_container_name="heavyai-db" # name of container the db instances runs in
 testscript_container_name="heavyai-test" # name of container the tests run in
 
 cpu_only=0
@@ -41,49 +38,12 @@ while [[ $# != 0 ]]; do
     -h|--help) usage ;;
     --cpu-only) cpu_only=1 ;;
     --gpu-only) gpu_only=1 ;;
-    --db-image) shift; db_image=$1 ;;
     -|-?*) usage "Unknown option: $1" ;;
     *) usage "Unexpected argument: $1" ;;
     esac
     shift
 done
 
-cleanup() {
-    docker rm -f $testscript_container_name &> /dev/null || true
-    docker rm -f $db_container_name &> /dev/null || true
-}
-
-print_db_logs() {
-    echo "=========================="
-    echo "  Begin DB Container Logs "
-    echo "=========================="
-    echo ""
-
-    docker logs $db_container_name
-
-    echo ""
-    echo "=========================="
-    echo "  End DB Container Logs "
-    echo "=========================="
-}
-
-exit_on_error() {
-    echo "=================================="
-    echo "  Failed with error code: $*" >&2
-    echo "  Showing DB logs before exiting"
-    echo "=================================="
-    print_db_logs
-    cleanup
-    exit 1
-}
-
-ready=1
-if ! [[ "$db_image" ]]; then
-    ready=
-    error "Required parameter missing: CPU docker image. Specify it using --db-image"
-fi
-
-[[ "$ready" ]] || exit 1
 
 test_heavyai() {
     # Forward args to build-conda.sh
@@ -115,21 +75,14 @@ test_heavyai() {
     return $?
 }
 
-cleanup
-
 # disable exit on error, so we still
-# get logs + perform cleanup
+# get logs
 set +o errexit
 
 if [[ gpu_only -eq 1 ]];then
-    test_heavyai --gpu-only || exit_on_error "$?"
+    test_heavyai --gpu-only
 fi
 
 if [[ cpu_only -eq 1 ]];then
-    test_heavyai --cpu-only || exit_on_error "$?"
+    test_heavyai --cpu-only
 fi
-
-echo "======================"
-echo "  Starting Cleanup"
-echo "======================"
-cleanup

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -132,18 +132,8 @@ start_docker_db() {
 #                ${db_params[*]} \
 #            "
 
-    mamba env create -n heavydb heavydb
-    conda activate heavydb
-
-    startheavy \
-            --non-interactive \
-            --data /heavydb-storage/data \
-            --enable-runtime-udfs \
-            --enable-table-functions \
-            ${db_params[*]} &
-
     # Tail logs for 10s to ensure that our db startup was successful.
-    timeout 10s docker logs -f "$db_container_name" || true
+#    timeout 10s docker logs -f "$db_container_name" || true
     return $?
 }
 
@@ -159,14 +149,15 @@ test_heavyai() {
         params+=("--runtime=nvidia")
     fi
 
+#        --ipc="container:${db_container_name}" \
+#        --env HEAVYDB_HOST="${db_container_name}" \
+
     docker run "${params[@]}" \
         --rm \
         -v ${WORKDIR}:/heavyai \
-        --ipc="container:${db_container_name}" \
         --interactive \
         --network="net_heavyai" \
         --workdir="/heavyai" \
-        --env HEAVYDB_HOST="${db_container_name}" \
         --name "${testscript_container_name}" \
         rapidsai/rapidsai-core:22.04-cuda11.0-base-ubuntu20.04-py3.9 \
         /heavyai/ci/build-conda.sh "$*"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ heavydb_host = os.environ.get('HEAVYDB_HOST', 'localhost')
 
 def _check_open():
     """
-    Test to see if OmniSci running on localhost and socket open
+    Test to see if HeavyDB running on localhost and socket open
     """
     socket = TSocket.TSocket(heavydb_host, 6274)
     transport = TTransport.TBufferedTransport(socket)
@@ -36,14 +36,14 @@ def mapd_server():
         pass
     else:
         raise RuntimeError(
-            "Unable to connect to OmniSci server at {}".format(heavydb_host)
+            f"Unable to connect to Heavydb server at {heavydb_host}"
         )
 
 
 @pytest.fixture(scope='session')
 def con(mapd_server):
     """
-    Fixture to provide Connection for tests run against live OmniSci instance
+    Fixture to provide Connection for tests run against live HeavyDB instance
     """
 
     return connect(
@@ -52,7 +52,7 @@ def con(mapd_server):
         host=heavydb_host,
         port=6274,
         protocol='binary',
-        dbname='omnisci',
+        dbname='heavyai',
     )
 
 
@@ -89,7 +89,7 @@ def gen_string():
 
 def _tests_table_no_nulls(n_samples):
     """
-    Generates a dataframe with all OmniSci types in it for use in integration
+    Generates a dataframe with all HeavyDB types in it for use in integration
     testing
     """
 

--- a/tests/test_deallocate.py
+++ b/tests/test_deallocate.py
@@ -22,7 +22,7 @@ class TestDeallocate:
             host='localhost',
             port=6274,
             protocol='binary',
-            dbname='omnisci',
+            dbname='heavyai',
         )
 
     def _transact(self, con):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -66,7 +66,7 @@ class TestIntegration:
             host=heavydb_host,
             port=6274,
             protocol='binary',
-            dbname='omnisci',
+            dbname='heavyai',
         )
         assert con is not None
 
@@ -77,21 +77,21 @@ class TestIntegration:
             host=heavydb_host,
             port=6278,
             protocol='http',
-            dbname='omnisci',
+            dbname='heavyai',
         )
         assert con is not None
 
     def test_connect_uri(self):
         uri = (
-            'heavydb://admin:HyperInteractive@{0}:6274/omnisci?'
-            'protocol=binary'.format(heavydb_host)
+            f'heavydb://admin:HyperInteractive@{heavydb_host}:6274/heavyai?'
+            'protocol=binary'
         )
         con = connect(uri=uri)
         assert con._user == 'admin'
         assert con._password == 'HyperInteractive'
         assert con._host == heavydb_host
         assert con._port == 6274
-        assert con._dbname == 'omnisci'
+        assert con._dbname == 'heavyai'
         assert con._protocol == 'binary'
 
     def test_connect_uri_and_others_raises(self):


### PR DESCRIPTION
This only update tests and doc. No release is required.

Tests will now use the `heavydb` conda image and connect to the default table `heavyai` of `heavydb`.