### PR TITLE
Update IPC to support new versions of arrow/cudf

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ To install heavyai for GPU Dataframe support (conda-only):
 
 ```bash
 mamba create -n heavyai-gpu -c rapidsai -c nvidia -c conda-forge -c defaults \
-    --no-channel-priority cudf pyheavydb pytest shapely geopandas pyarrow=*=*cuda
+    --no-channel-priority \
+    cudf heavyai pyheavydb pytest shapely geopandas pyarrow=*=*cuda
 ```
 
 Documentation

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ heavyai with GPU capabilities.
 To install heavyai for GPU Dataframe support (conda-only):
 
 ```bash
-mamba create -n heavyai-gpu -c rapidsai -c nvidia -c conda-forge -c defaults cudf heavyai pyheavydb
+mamba create -n heavyai-gpu -c rapidsai -c nvidia -c conda-forge -c defaults \
+    --no-channel-priority cudf pyheavydb pytest shapely geopandas pyarrow=*=*cuda
 ```
 
 Documentation

--- a/heavyai/_utils.py
+++ b/heavyai/_utils.py
@@ -137,7 +137,7 @@ def _parse_tdf_gpu(tdf):
         # columns
         pass
 
-    batch = pa.ipc.read_record_batch(ipc_buf.to_pybytes(), schema)
+    batch = pa._cuda.read_record_batch(ipc_buf, schema)
     table = pa.Table.from_batches([batch])
     df = DataFrame()
     df.set_tdf = MethodType(set_tdf, df)

--- a/heavyai/_utils.py
+++ b/heavyai/_utils.py
@@ -143,13 +143,15 @@ def _parse_tdf_gpu(tdf):
     df.set_tdf = MethodType(set_tdf, df)
     df.get_tdf = MethodType(get_tdf, df)
 
+    # convert table -> cuDF first
     for name in table.column_names:
-        if name in dict_memo:
-            indices = table[name].combine_chunks()
-            dictionary = dict_memo[name]
-            df[name] = pa.DictionaryArray.from_arrays(indices, dictionary)
-        else:
-            df[name] = table[name]
+        df[name] = table[name]
+
+    # remap dictionary nodes
+    for name in dict_memo.keys():
+        indices = df[name].to_arrow()
+        dictionary = dict_memo[name]
+        df[name] = pa.DictionaryArray.from_arrays(indices, dictionary)
 
     df.set_tdf(tdf)
 

--- a/heavyai/connection.py
+++ b/heavyai/connection.py
@@ -314,7 +314,6 @@ class Connection(heavydb.Connection):
         where HeavyDB running.
         """
         try:
-            from cudf.comm.gpuarrow import GpuArrowReader  # noqa
             from cudf.core.dataframe import DataFrame  # noqa
         except ImportError:
             raise ImportError(


### PR DESCRIPTION
`GPUArrowReader` was removed a year ago in cuDF (https://github.com/rapidsai/cudf/pull/10995). This PR removes it and replace by a pure pyarrow implementation.

Edit: [JIRA Ticket](https://heavyai.atlassian.net/browse/QE-686)