### PR TITLE
Update `build.os` in .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,10 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
 python:
   version: 3.8
   install:


### PR DESCRIPTION
Fix readthedocs build error by specifying the build container.

See: https://blog.readthedocs.com/use-build-os-config/

Unfortunately, I can not see a means to launch a readthedocs build job for a branch to test this change. I believe an admin on readthedocs is able to test these changes, but I do not see the options described in this issue: https://github.com/readthedocs/readthedocs.org/issues/4